### PR TITLE
Update viper.go

### DIFF
--- a/viper.go
+++ b/viper.go
@@ -48,7 +48,6 @@ const (
 func NewBundle(options ...Option) *Bundle {
 	var opts = []Option{
 		AutomaticEnv(),
-		EnvPrefix("ENV"),
 		EnvKeyReplacer(strings.NewReplacer(".", "_")),
 		ConfigName("config"),
 		ConfigType("json"),


### PR DESCRIPTION
It's better to leave it in the options.
Because back in the viper you can not put ""